### PR TITLE
hosted-zone api and related scan/task/explorer updates

### DIFF
--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -2168,7 +2168,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Task'
+              $ref: '#/components/schemas/TaskOptions'
       responses:
         '200':
           description: task details

--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -5816,15 +5816,18 @@ components:
           format: int64
           example: 0
 
-    Task:
+    TaskBase:
+      description: All fields of a Task with none required
       type: object
-      required:
-        - id
       properties:
         id:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         name:
           type: string
           example: Hourly Scan
@@ -5835,38 +5838,88 @@ components:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         client_id:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         organization_id:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         agent_id:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
+        hosted_zone_id:
+          description: |
+            The ID of the Hosted Zone which executes the task. If the
+          type: string
+          format: uuid
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         site_id:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         cruncher_id:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         created_at:
           type: integer
           format: int64
           example: 1576300370
         created_by:
           type: string
-          format: email
           example: user@example.com
         created_by_user_id:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
+        custom_integration_id:
+          description: The ID of the custom integration source, if the last task executed with this template was an import of Asset Data.
+          type: string
+          format: uuid
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
+        source_id:
+          description: The numeric ID of the data source, if the task executed with this template is a runZero scan or third party data connection import.
+          type: integer
+          example: 1
         updated_at:
           type: integer
           format: int64
@@ -5894,12 +5947,16 @@ components:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         recur:
           type: boolean
           example: false
         recur_frequency:
           type: string
-          example: hour
+          example: hourly
         start_time:
           type: integer
           format: int64
@@ -5916,6 +5973,27 @@ components:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
+
+    Task:
+      description: A task object
+      required:
+        - id
+      allOf:
+        - $ref: "#/components/schemas/TaskBase"
+
+    TaskOptions:
+      description: Options which can be set to create or modify a task.
+      properties:
+        hosted_zone_name:
+          type: string
+          example: auto
+          description: The string 'auto' will use any available hosted zone. Otherwise, provide the string name (hostedzone1) of the hosted zone.
+      allOf:
+        - $ref: "#/components/schemas/TaskBase"
 
     License:
       type: object
@@ -6485,6 +6563,7 @@ components:
         hidden:
           type: boolean
           example: true
+
 
     AssetOwnershipTypePost:
       type: object

--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -1303,6 +1303,56 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
 
+  /org/hosted-zones:
+    parameters:
+      - $ref: '#/components/parameters/orgID'
+    get:
+      tags:
+        - Organization
+      operationId: getHostedZones
+      summary: Get all hosted zones
+      description: Get all hosted zones. Hosted Zones are only available to Enterprise licensed customers.
+      responses:
+        '200':
+          description: array of hosted zones
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HostedZone'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+
+  /org/hosted-zones/{hosted_zone_id}:
+    parameters:
+      - $ref: '#/components/parameters/orgID'
+    get:
+      tags:
+        - Organization
+      operationId: getHostedZone
+      summary: Get details for a single hosted zone.
+      description: Get details for a single Hosted Zone. Hosted Zones are only available to Enterprise licensed customers.
+      parameters:
+        - in: path
+          name: hosted_zone_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: UUID of the hosted zone
+      responses:
+        '200':
+          description: hosted zone details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostedZone'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+
   /org/sites:
     parameters:
       - $ref: '#/components/parameters/orgID'
@@ -5994,6 +6044,62 @@ components:
           description: The string 'auto' will use any available hosted zone. Otherwise, provide the string name (hostedzone1) of the hosted zone.
       allOf:
         - $ref: "#/components/schemas/TaskBase"
+
+    HostedZone:
+      description: |
+        A hosted service which performs scan tasks. Hosted zones are only available to
+        Enterprise customers.
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          description: The ID of the hosted zone
+          type: string
+          format: uuid
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+        name:
+          type: string
+          example: zone1
+        enabled:
+          description: Whether the hosted zone is enabled
+          type: boolean
+          example: true
+        updated_at:
+          description: The last modification time of the hosted zone
+          type: string
+          format: date-time
+          example: "2023-03-06T18:14:50.52Z"
+        processor_id:
+          description: The processor ID assigned to the hosted zone
+          type: string
+          format: uuid
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+        explorers_concurrency:
+          description: The number of concurrent explorer tasks that can be executed
+          type: integer
+          format: int64
+          example: 0
+        explorers_total:
+          description: The number of explorers available in the zone
+          type: integer
+          format: int64
+          example: 0
+        tasks_active:
+          description: The number of tasks executing in the zone
+          type: integer
+          format: int64
+          example: 0
+        tasks_waiting:
+          description: The number of tasks waiting to execute in the zone
+          type: integer
+          format: int64
+          example: 0
+        organization_id:
+          description: The ID of the organization the hosted zone is assigned to
+          type: string
+          format: uuid
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
 
     License:
       type: object

--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -1311,7 +1311,7 @@ paths:
         - Organization
       operationId: getExplorers
       summary: Get all explorers
-      description: Get all explorers. This is the same call as legacy path, /org/agents
+      description: Get all explorers. This is the same call as legacy path /org/agents
       responses:
         '200':
           description: array of agents
@@ -1332,7 +1332,7 @@ paths:
         - Organization
       operationId: getExplorer
       summary: Get details for a single explorer.
-      description: Get details for a single explorer. This is the same call as legacy path, /org/agents/{agent_id}
+      description: Get details for a single explorer. This is the same call as legacy path /org/agents/{agent_id}
       parameters:
         - in: path
           name: explorer_id
@@ -1357,7 +1357,7 @@ paths:
         - Organization
       operationId: removeExplorer
       summary: Remove and uninstall an explorer
-      description: Remove and uninstall an explorer. This is the same call as legacy path, /org/agents/{agent_id}
+      description: Remove and uninstall an explorer. This is the same call as legacy path /org/agents/{agent_id}
       parameters:
         - in: path
           name: explorer_id
@@ -1378,7 +1378,7 @@ paths:
         - Organization
       operationId: updateExplorerSite
       summary: Update the site associated with the explorer
-      description: Update the site associated with the explorer. This is the same call as legacy path, /org/agents/{agent_id}
+      description: Update the site associated with the explorer. This is the same call as legacy path /org/agents/{agent_id}
       parameters:
         - in: path
           name: explorer_id
@@ -1414,7 +1414,7 @@ paths:
         - Organization
       operationId: upgradeExplorer
       summary: Force an explorer to update and restart
-      description: Force an explorer to update and restart. This is the same call as legacy path, /org/agents/{agent_id}/update
+      description: Force an explorer to update and restart. This is the same call as legacy path /org/agents/{agent_id}/update
       parameters:
         - in: path
           name: explorer_id
@@ -6954,7 +6954,6 @@ components:
         hidden:
           type: boolean
           example: true
-
 
     AssetOwnershipTypePost:
       type: object

--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -4,7 +4,7 @@ servers:
     url: https://console.runzero.com/api/v1.0
 info:
   description: runZero API. API use is rate limited, you can make as many calls per day as you have licensed assets.
-  version: 3.6.0
+  version: 3.7.6
   title: runZero API
   contact:
     email: support@runzero.com

--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -4276,6 +4276,7 @@ components:
           example: https://www.runzero.com/docs/
 
     ScanOptions:
+      description: Options which can be set to create or modify a scan.
       type: object
       required:
         - targets
@@ -4289,14 +4290,21 @@ components:
           type: string
           example: My Scan
         scan-description:
+          description: A description of the scan.
           type: string
           example: Scan of Wireless
+        scan-template:
+          type: string
+          format: uuid
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         scan-frequency:
+          description: A string time duration value representing execution frequency, if scheduled to repeat.
           type: string
           enum: [once, hourly, daily, weekly, monthly, continuous]
+          example: hour
         scan-start:
+          description: Unix timestamp value indicating when the template was created.
           type: string
-          format: unixtime
           example: "0"
         scan-tags:
           type: string
@@ -4308,6 +4316,18 @@ components:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+        explorer:
+          type: string
+          format: uuid
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+        hosted-zone-id:
+          type: string
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          description: The string 'auto' will use any available hosted zone. Otherwise, provide the string name (hostedzone1) or UUID (e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8) of a hosted zone.
+        hosted-zone-name:
+          type: string
+          example: auto
+          description: The string 'auto' will use any available hosted zone. Otherwise, provide the string name (hostedzone1) of the hosted zone.
         rate:
           type: string
           example: "10000"
@@ -4329,6 +4349,9 @@ components:
         max-ttl:
           type: string
           example: "255"
+        tos:
+          type: string
+          example: "255"
         tcp-ports:
           type: string
           example: "1-1000,5000-6000"
@@ -4347,12 +4370,20 @@ components:
         subnet-ping-net-size:
           type: string
           example: "256"
+        subnet-ping-probes:
+          type: string
+          description: Optional subnet ping probe list as comma separated strings. The example shows possibilities.
+          example: arp, echo, syn, connect, netbios, snmp, ntp, sunrpc, ike, openvpn, mdns
         subnet-ping-sample-rate:
           type: string
           example: "3"
         host-ping:
           type: string
           example: "false"
+        host-ping-probes:
+          type: string
+          description: Optional host ping probe list as comma separated strings. The example shows possibilities.
+          example: arp, echo, syn, connect, netbios, snmp, ntp, sunrpc, ike, openvpn, mdns
         probes:
           type: string
           description: Optional probe list, otherwise all probes are used
@@ -4360,130 +4391,211 @@ components:
         # Probe options are also supported with values like: dns-port: "53"
 
     ScanTemplateOptions:
+      description: Options which can be set to create a scan template.
       type: object
       required:
         - name
+        - organization_id
         - global
         - acl
       properties:
         name:
+          description: Name of the template.
           type: string
           example: My Scan Template
         description:
+          description: Description of the template.
           type: string
           example: My Scan Template
+        organization_id:
+          description: The ID of the organization the template will be created in
+          type: string
+          format: uuid
+          example: f6cfb91a-52ea-4a86-bf9a-5a891a26f52b
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         params:
+          description: A number of scan parameter values. Currently there is no authoritative list of acceptable values. See existing templates for examples.
           type: object
           additionalProperties:
             type: string
         global:
+          description: Whether the template is globally available to all organizations.
           type: boolean
           example: false
         acl:
+          description: A map of IDs to strings which describe how the template may be accessed. Currently there is no authoritative list of acceptable values. See existing templates for examples.
           type: object
           additionalProperties: true
           example:
             e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8: user
 
     ScanTemplate:
+      description: A scan task template
       type: object
       required:
         - id
         - global
+        - organization_id
         - acl
       properties:
         id:
+          description: ID of the template.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
+        name:
+          description: The name of the template.
+          type: string
+          example: My Scan Template
+        description:
+          description: The description of the template.
+          type: string
+          example: My Scan Template
         client_id:
+          description: ID of the account which owns the template.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         organization_id:
+          description: ID of the organization the template is available in.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         agent_id:
+          description: ID of the explorer which may execute the template.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         site_id:
+          description: ID of the site the template is being used in.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         cruncher_id:
+          description: ID of the runZero cruncher the task is executing on.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         created_at:
+          description: Unix timestamp value indicating when the template was created.
           type: integer
           format: int64
           example: 1576300370
         created_by:
+          description: The username of the account which created the template.
           type: string
-          format: email
           example: user@example.com
         created_by_user_id:
+          description: The ID of the account which created the template.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         updated_at:
+          description: Unix timestamp value indicating when the template was last modified.
           type: integer
           format: int64
           example: 1576300370
         type:
+          description: The type of task the template creates.
           type: string
           example: scan
         status:
+          description: The status of the last task using the template.
           type: string
           example: processed
         error:
+          description: The error message, if any, of the last task using the template.
           type: string
           example: agent unavailable
         params:
+          description: A number of task parameter values. Currently there is no authoritative list of in-use values. See existing templates for examples.
           type: object
           additionalProperties:
             type: string
         stats:
+          description: A map of statistics about the last task executed with the template. Currently there is no authoritative list of in-use values. See existing templates for examples.
           type: object
           additionalProperties: true
         hidden:
+          description: A flag indicating whether the item is hidden from common view.
           type: boolean
           example: false
         parent_id:
+          description: The ID of the parent entity of the task scheduled.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         recur:
+          description: A flag representing whether derived tasks are scheduled to repeat.
           type: boolean
           example: false
         recur_frequency:
+          description: |
+            A string time duration value representing execution frequency, if scheduled to repeat. You may use
+            values including as once, hourly, daily, weekly, monthly, continuous
           type: string
-          example: hour
+          example: hourly
         start_time:
+          description: Unix timestamp representing the next execution time.
           type: integer
           format: int64
           example: 1576300370
         recur_last:
+          description: Unix timestamp representing the last execution if scheduled to repeat.
           type: integer
           format: int64
           example: 1576300370
         recur_next:
+          description: Unix timestamp representing the next execution if scheduled to repeat.
           type: integer
           format: int64
           example: 1576300370
         recur_last_task_id:
+          description: The ID of the task that last executed if scheduled to repeat.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
-        name:
-          type: string
-          example: My Scan Template
-        description:
-          type: string
-          example: My Scan Template
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         grace_period:
+          description: Additional time beyond hard expiration deadline by which the task may still be allowed to execute.
           type: string
           example: "4"
         custom_integration_id:
@@ -4496,36 +4608,62 @@ components:
             name: uuid
             path: github.com/gofrs/uuid
         source_id:
+          description: The numeric ID of the data source, if the task executed with this template is a runZero scan or third party data connection import.
           type: string
           example: "1"
-        template_id:
+        custom_integration_id:
+          description: The ID of the custom integration source, if the last task executed with this template was an import of Asset Data.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
+        template_id:
+          description: The ID of the template.
+          type: string
+          format: uuid
+          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         size_site:
+          description: The size in assets of the site the last task the template was executed against.
           type: integer
           format: int64
           example: 0
         size_data:
+          description: The total size of result data of the last task the template was used with.
           type: integer
           format: int64
           example: 0
         size_results:
+          description: The number of results in the last task the template was used with.
           type: integer
           format: int64
           example: 0
         hosted_zone_id:
+          description: The ID of the hosted zone that ran the last task the template was used with.
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         linked_task_count:
+          description: The number of tasks derived from the template.
           type: integer
           format: int32
           example: 1
         global:
+          description: Whether the template is globally available to all organizations.
           type: boolean
           example: false
         acl:
+          description: A map of IDs to strings which describe how the template may be accessed. Currently there is no authoritative list of in-use values. See existing templates for examples.
           type: object
           additionalProperties: true
           example:
@@ -5580,6 +5718,10 @@ components:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         created_at:
           type: integer
           format: int64
@@ -5592,6 +5734,10 @@ components:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+          x-go-type: uuid.UUID
+          x-go-import:
+            name: uuid
+            path: github.com/gofrs/uuid
         download_token:
           type: string
           example: DT11226D9EEEA2B035D42569585900

--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -1187,7 +1187,7 @@ paths:
       tags:
         - Organization
       operationId: getAgents
-      summary: Get all agents
+      summary: Get all agents. Legacy path for /org/explorers
       responses:
         '200':
           description: array of agents
@@ -1207,7 +1207,7 @@ paths:
       tags:
         - Organization
       operationId: getAgent
-      summary: Get details for a single agent
+      summary: Get details for a single agent. Legacy path for /org/explorers/{explorer_id}
       parameters:
         - in: path
           name: agent_id
@@ -1231,7 +1231,7 @@ paths:
       tags:
         - Organization
       operationId: removeAgent
-      summary: Remove and uninstall an agent
+      summary: Remove and uninstall an agent. Legacy path for /org/explorers/{explorer_id}
       parameters:
         - in: path
           name: agent_id
@@ -1251,7 +1251,7 @@ paths:
       tags:
         - Organization
       operationId: updateAgentSite
-      summary: Update the site associated with agent
+      summary: Update the site associated with agent. Legacy path for /org/explorers/{explorer_id}
       parameters:
         - in: path
           name: agent_id
@@ -1286,7 +1286,7 @@ paths:
       tags:
         - Organization
       operationId: upgradeAgent
-      summary: Force an agent to update and restart
+      summary: Force an agent to update and restart. Legacy path for /org/explorers/{explorer_id}/update
       parameters:
         - in: path
           name: agent_id
@@ -1295,6 +1295,134 @@ paths:
             format: uuid
           required: true
           description: UUID of the agent to update
+      responses:
+        '204':
+          description: empty response
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+
+  /org/explorers:
+    parameters:
+      - $ref: '#/components/parameters/orgID'
+    get:
+      tags:
+        - Organization
+      operationId: getExplorers
+      summary: Get all explorers
+      description: Get all explorers. This is the same call as legacy path, /org/agents
+      responses:
+        '200':
+          description: array of agents
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Explorer'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+
+  /org/explorers/{explorer_id}:
+    parameters:
+      - $ref: '#/components/parameters/orgID'
+    get:
+      tags:
+        - Organization
+      operationId: getExplorer
+      summary: Get details for a single explorer.
+      description: Get details for a single explorer. This is the same call as legacy path, /org/agents/{agent_id}
+      parameters:
+        - in: path
+          name: explorer_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: UUID of the explorer
+      responses:
+        '200':
+          description: explorer details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Explorer'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+    delete:
+      tags:
+        - Organization
+      operationId: removeExplorer
+      summary: Remove and uninstall an explorer
+      description: Remove and uninstall an explorer. This is the same call as legacy path, /org/agents/{agent_id}
+      parameters:
+        - in: path
+          name: explorer_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: UUID of the explorer to remove
+      responses:
+        '204':
+          description: empty response
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+    patch:
+      tags:
+        - Organization
+      operationId: updateExplorerSite
+      summary: Update the site associated with the explorer
+      description: Update the site associated with the explorer. This is the same call as legacy path, /org/agents/{agent_id}
+      parameters:
+        - in: path
+          name: explorer_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: UUID of the explorer to update
+      requestBody:
+        description: site_id to associate with the explorer
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExplorerSiteID"
+      responses:
+        '200':
+          description: explorer details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Explorer'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+
+  /org/explorers/{explorer_id}/update:
+    parameters:
+      - $ref: '#/components/parameters/orgID'
+    post:
+      tags:
+        - Organization
+      operationId: upgradeExplorer
+      summary: Force an explorer to update and restart
+      description: Force an explorer to update and restart. This is the same call as legacy path, /org/agents/{agent_id}/update
+      parameters:
+        - in: path
+          name: explorer_id
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: UUID of the explorer to update
       responses:
         '204':
           description: empty response
@@ -4669,6 +4797,8 @@ components:
           example:
             e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8: user
 
+
+
     AgentSiteID:
       type: object
       required:
@@ -4678,6 +4808,13 @@ components:
           type: string
           format: uuid
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
+
+    Explorer:
+      $ref: '#/components/schemas/Agent'
+
+    ExplorerSiteID:
+      $ref: '#/components/schemas/AgentSiteID'
+
     OrgOptions:
       type: object
       properties:
@@ -5940,6 +6077,9 @@ components:
           example: org
 
     Agent:
+      description: |
+        A deployed service which performs scan tasks.
+        Explorers may be referred to by their legacy name, Agents.
       type: object
       required:
         - id
@@ -5973,7 +6113,6 @@ components:
           example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
         name:
           type: string
-          format: hostname
           example: RUNZERO-AGENT
         site_id:
           type: string


### PR DESCRIPTION
Adds new /hosted-zones API and supporting objects

Splits Task into components:
  * TaskBase, Task, TaskOptions have different fields and requirements
  * TaskOptions can accept information about a hosted zone

Adds entirely new fields:
  * ScanOptions:
    * Adds hosted_zone_name and ID field, which can be used during scan creation to specify that the scan should be executed by a hosted zone.
  * ScanTemplate:
    * Adds custom_integration_id field
  * ScanTemplateOptions:
    * Adds custom_integration_id field
  * TaskBase:
    * Adds custom_integration_id field

Documents endpoints and fields that existed previously:
  * /explorers (same as /agents) routes and objects, noting that agent is legacy terminology
  * ScanOptions:
    * Documents existing scan-template field
    * Documents existing explorer field
  * ScanTemplateOptions
    * Documents the organization_id field, which is required
  * TaskBase:
    * Documents the source_id field
    * Documents the hosted_zone_id field


Other small updates to formats and descriptions.