### PR TITLE
Remove spurious runZeroID

### DIFF
--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -4,7 +4,7 @@ servers:
     url: https://console.runzero.com/api/v1.0
 info:
   description: runZero API. API use is rate limited, you can make as many calls per day as you have licensed assets.
-  version: 3.7.6
+  version: 3.7.7
   title: runZero API
   contact:
     email: support@runzero.com
@@ -2450,7 +2450,7 @@ paths:
       tags:
         - Organization
       operationId: stopTask
-      summary: Signal that a task should be stopped or canceledThis will also remove recurring and scheduled tasks
+      summary: Signal that a task should be stopped or canceled.This will also remove recurring and scheduled tasks
       parameters:
         - in: path
           name: task_id

--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -7124,15 +7124,6 @@ components:
           x-go-import:
             name: uuid
             path: github.com/gofrs/uuid
-        runZeroId:
-          description: The unique ID of the runZero asset to force a merge onto. It is not necessary to provide this data, merging will work according to typical runZero merge rules otherwise.
-          type: string
-          format: uuid
-          example: e77602e0-3fb8-4734-aef9-fbc6fdcb0fa8
-          x-go-type: uuid.UUID
-          x-go-import:
-            name: uuid
-            path: github.com/gofrs/uuid
 
         importTask:
           title: ImportTask


### PR DESCRIPTION
This property belongs only the ImportAsset object. Setting the removed property would result in the server dropping it.