### PR TITLE
Expose API endpoints to remove custom integration sources from assets

### DIFF
--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -2197,7 +2197,40 @@ paths:
         '400':
           $ref: '#/components/responses/InvalidRequestBodyError'
         '403':
+          $ref: '#/components/responses/InternalServerError'
+
+  /org/custom-integrations/{custom_integration_id}/bulk/remove:
+    parameters:
+    - in: path
+      name: custom_integration_id
+      schema:
+        type: string
+        format: uuid
+      required: true
+      description: UUID of the custom integration
+    post:
+      tags:
+        - Organization
+      operationId: bulkRemoveCustomIntegration
+      summary: Remove custom integration from a list of assets
+      requestBody:
+        description: list of asset IDs to remove
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetIDs'
+      responses:
+        '204':
+          description: empty response
+        '400':
+          $ref: '#/components/responses/InvalidRequestParamError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
           $ref: '#/components/responses/NotAllowedForLicenseError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -2201,6 +2201,72 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /org/assets/{asset_id}/custom-integrations/{custom_integration_id}/remove:
+    parameters:
+    - in: path
+      name: asset_id
+      schema:
+        type: string
+        format: uuid
+      required: true
+      description: UUID of the asset to update
+    - in: path
+      name: custom_integration_id
+      schema:
+        type: string
+        format: uuid
+      required: true
+      description: UUID of the custom integration
+    delete:
+      tags:
+        - Organization
+      operationId: removeCustomIntegration
+      summary: Remove single custom integration from asset
+      responses:
+        '204':
+          description: empty response
+        '400':
+          $ref: '#/components/responses/InvalidRequestParamError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/NotAllowedForLicenseError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /org/assets/{asset_id}/sources/{source_id}/remove:
+    parameters:
+    - in: path
+      name: asset_id
+      schema:
+        type: string
+        format: uuid
+      required: true
+      description: UUID of the asset to update
+    - in: path
+      name: source_id
+      schema:
+        type: string
+        format: uuid
+      required: true
+      description: UUID of the source
+    delete:
+      tags:
+        - Organization
+      operationId: removeAssetSource
+      summary: Remove single source from asset
+      responses:
+        '204':
+          description: empty response
+        '400':
+          $ref: '#/components/responses/InvalidRequestParamError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/NotAllowedForLicenseError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /org/custom-integrations:
     get:
       tags:


### PR DESCRIPTION
Includes missing API endpoints for removing integration sources from an asset:

```api
POST     /org/custom-integrations/{custom_integration_id}/bulk/remove
DELETE   /org/assets/{asset_id}/custom-integrations/{custom_integration_id}/remove
DELETE   /org/assets/{asset_id}/sources/{source_id}/remove
```
