### PR TITLE
Temporarily withdraw certificate JSON API while we revise

### DIFF
--- a/runzero-api.yml
+++ b/runzero-api.yml
@@ -561,47 +561,49 @@ paths:
         '401':
           $ref: '#/components/responses/UnauthorizedError'
 
-  /export/org/certificates.json:
-    parameters:
-      - $ref: '#/components/parameters/orgID'
-      - $ref: '#/components/parameters/search'
-    get:
-      tags:
-        - Export
-        - Certificates
-      operationId: exportCertificatesJSON
-      summary: Export the certificate inventory as JSON
-      responses:
-        '200':
-          description: filtered certificate results
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Certificate"
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-
-  /export/org/certificates.jsonl:
-    parameters:
-      - $ref: '#/components/parameters/orgID'
-      - $ref: '#/components/parameters/search'
-    get:
-      tags:
-        - Export
-        - Certificates
-      operationId: exportCertificatesJSONL
-      summary: Export the certificate inventory as JSONL line-delimited
-      responses:
-        '200':
-          description: filtered certificate results
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Certificate"
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
+# Temporarily withdrawn pending possible changes to the schema
+#
+#  /export/org/certificates.json:
+#    parameters:
+#      - $ref: '#/components/parameters/orgID'
+#      - $ref: '#/components/parameters/search'
+#    get:
+#      tags:
+#        - Export
+#        - Certificates
+#      operationId: exportCertificatesJSON
+#      summary: Export the certificate inventory as JSON
+#      responses:
+#        '200':
+#          description: filtered certificate results
+#          content:
+#            application/json:
+#              schema:
+#                type: array
+#                items:
+#                  $ref: "#/components/schemas/Certificate"
+#        '401':
+#          $ref: '#/components/responses/UnauthorizedError'
+#
+#  /export/org/certificates.jsonl:
+#    parameters:
+#      - $ref: '#/components/parameters/orgID'
+#      - $ref: '#/components/parameters/search'
+#    get:
+#      tags:
+#        - Export
+#        - Certificates
+#      operationId: exportCertificatesJSONL
+#      summary: Export the certificate inventory as JSONL line-delimited
+#      responses:
+#        '200':
+#          description: filtered certificate results
+#          content:
+#            application/json:
+#              schema:
+#                $ref: "#/components/schemas/Certificate"
+#        '401':
+#          $ref: '#/components/responses/UnauthorizedError'
 
   /export/org/users.json:
     parameters:


### PR DESCRIPTION
After back end changes it probably makes sense to revise the certificate schema to make it single level. So far only a few customers have even tried the API, and nobody seems to be using it regularly.